### PR TITLE
fix: use kobble.Options{} instead of kobble.Options and specify import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@
 Initialize a `Kobble` instance from a secret generated from your [Kobble dashboard](https://app.kobble.io/p/project/admin-sdk).
 
 ```go
+import (
+    "github.com/valensto/kobble-go-sdk/kobble"
+)
+
 func main() {
-    k := kobble.New("YOUR_SECRET", kobble.Options)
+    k := kobble.New("YOUR_SECRET", kobble.Options{})
     whoami, err := k.Whoami()
     if err != nil {
         log.Fatal(err)
@@ -33,8 +37,10 @@ func main() {
 You can verify **ID tokens** obtained using Kobble frontend SDKs as follows:
 
 ```go
+
+
 func main() {
-    k := kobble.New("YOUR_SECRET", kobble.Options)
+    k := kobble.New("YOUR_SECRET", kobble.Options{})
     result, err := k.Auth.VerifyIdToken("ID_TOKEN")
     if err != nil {
         log.Fatal(err)


### PR DESCRIPTION
Hi, Kobble co-founder here.

First of all thank you very much for this port, this is extremely helpful and it looks very well thought out from what I've reviewed so far. As a casual go coder myself this is really appreciated.

I was able to test part of it and everything worked as it should.

In this PR I corrected a few issues I was able to find in the README:
- `kobble.Options` should be `kobble.Options{}`
- The proper import to use should be specified at least one time to facilitate the installation of the package